### PR TITLE
feat: Implement Notion DB and Properties APIs

### DIFF
--- a/src/application/dtos/notionDatabaseDTOs.ts
+++ b/src/application/dtos/notionDatabaseDTOs.ts
@@ -1,0 +1,36 @@
+// src/application/dtos/notionDatabaseDTOs.ts
+
+// DTOs for List Accessible Notion Databases API
+export interface ListNotionDatabasesInput {
+  integrationId: string;
+  userId: string;
+}
+
+export interface NotionDatabaseOutputItem {
+  id: string;
+  name: string;
+}
+
+export interface ListNotionDatabasesOutput extends Array<NotionDatabaseOutputItem> {}
+
+// DTOs for Get Specific Notion Database Properties API
+export interface GetNotionDatabasePropertiesInput {
+  databaseId: string;
+  userId: string;
+  integrationId?: string; // Strongly recommended, will be treated as mandatory by use case
+}
+
+export interface NotionPropertyOption {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface NotionPropertyOutputItem {
+  id: string;
+  name: string;
+  type: string;
+  options?: NotionPropertyOption[];
+}
+
+export interface GetNotionDatabasePropertiesOutput extends Array<NotionPropertyOutputItem> {}

--- a/src/application/usecases/getNotionDatabasePropertiesUseCase.ts
+++ b/src/application/usecases/getNotionDatabasePropertiesUseCase.ts
@@ -1,0 +1,113 @@
+// src/application/usecases/getNotionDatabasePropertiesUseCase.ts
+import type { UserNotionIntegrationRepository } from '../../domain/repositories/userNotionIntegrationRepository';
+import type { EncryptionService } from '../services/encryptionService';
+import type { NotionApiService, NotionDatabaseSchema } from '../../domain/services/notionApiService';
+import type { CacheService } from '../services/cacheService';
+import type { 
+    GetNotionDatabasePropertiesInput, 
+    GetNotionDatabasePropertiesOutput,
+    NotionPropertyOutputItem,
+    NotionPropertyOption 
+} from '../dtos/notionDatabaseDTOs';
+import { HTTPException } from 'hono/http-exception';
+
+const CACHE_TTL_SECONDS_PROPERTIES = 1800; // 30 minutes, same as schema for consistency
+
+export class GetNotionDatabasePropertiesUseCase {
+  constructor(
+    private readonly userNotionIntegrationRepository: UserNotionIntegrationRepository,
+    private readonly encryptionService: EncryptionService,
+    private readonly notionApiService: NotionApiService,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async execute(input: GetNotionDatabasePropertiesInput): Promise<GetNotionDatabasePropertiesOutput> {
+    const { databaseId, userId, integrationId } = input;
+
+    if (!integrationId) {
+      // As per spec, integrationId is "strongly recommended" but "may be treated as mandatory".
+      // For robust behavior and clear authorization, we'll treat it as mandatory here.
+      throw new HTTPException(400, { 
+        message: 'integrationId query parameter is required to specify which Notion integration to use.',
+        cause: 'MissingIntegrationId'
+      });
+    }
+
+    // 1. Fetch UserNotionIntegration
+    const integration = await this.userNotionIntegrationRepository.findById(integrationId, userId);
+    if (!integration) {
+      throw new HTTPException(404, { 
+        message: `Notion integration with ID ${integrationId} not found or not accessible by user.`,
+        cause: 'UserNotionIntegrationNotFound' 
+      });
+    }
+
+    // 2. Decrypt notionIntegrationToken
+    let decryptedToken: string;
+    try {
+      // Assuming the token property name is 'notionIntegrationToken' based on previous subtask report
+      decryptedToken = await this.encryptionService.decrypt(integration.notionIntegrationToken);
+    } catch (error) {
+      console.error(`Failed to decrypt token for integration ID ${integrationId}:`, error);
+      throw new HTTPException(500, { 
+        message: 'Failed to decrypt Notion integration token.',
+        cause: 'DecryptionError'
+      });
+    }
+
+    // 3. Cache Logic
+    const cacheKey = `notion_db_properties_${databaseId}_integ_${integrationId}`; // Include integrationId in cache key for safety, though token implies access
+    
+    const cachedProperties = await this.cacheService.get<GetNotionDatabasePropertiesOutput>(cacheKey);
+    if (cachedProperties) {
+      console.log(`Cache hit for Notion database properties: ${databaseId} using integration ${integrationId}`);
+      return cachedProperties;
+    }
+    console.log(`Cache miss for Notion database properties: ${databaseId} using integration ${integrationId}. Fetching...`);
+
+    // 4. Fetch Schema from NotionApiService
+    let notionSchema: NotionDatabaseSchema | null;
+    try {
+      notionSchema = await this.notionApiService.getDatabaseSchema(databaseId, decryptedToken);
+    } catch (error: any) {
+      console.error(`Error calling getDatabaseSchema for DB ${databaseId} with integration ${integrationId}:`, error);
+      if (error instanceof HTTPException) throw error; // Re-throw if already an HTTPException
+      throw new HTTPException(500, {
+        message: `Failed to retrieve database schema from Notion API.`,
+        cause: error.message || 'NotionApiErrorFetchingSchema'
+      });
+    }
+    
+    if (!notionSchema) {
+      // This specific databaseId might not be accessible/found with this user's token,
+      // or the getDatabaseSchema itself returned null due to Notion API 404.
+      throw new HTTPException(404, { 
+        message: `Notion database with ID ${databaseId} not found or not accessible with the provided integration.`,
+        cause: 'NotionDatabaseNotFoundOrInaccessible'
+      });
+    }
+
+    // 5. Transform properties from Record to Array and map to Output DTO
+    const outputProperties: GetNotionDatabasePropertiesOutput = Object.values(notionSchema.properties).map(propSchema => {
+      const outputItem: NotionPropertyOutputItem = {
+        id: propSchema.id,
+        name: propSchema.name,
+        type: propSchema.type,
+      };
+      if (propSchema.options) {
+        outputItem.options = propSchema.options.map(opt => ({
+          id: opt.id,
+          name: opt.name,
+          color: opt.color,
+        }));
+      }
+      return outputItem;
+    });
+
+    // 6. Store in Cache
+    await this.cacheService.set(cacheKey, outputProperties, CACHE_TTL_SECONDS_PROPERTIES);
+    console.log(`Notion database properties for ${databaseId} (integration ${integrationId}) stored in cache.`);
+
+    return outputProperties;
+  }
+}

--- a/src/application/usecases/listNotionDatabasesUseCase.ts
+++ b/src/application/usecases/listNotionDatabasesUseCase.ts
@@ -1,0 +1,67 @@
+// src/application/usecases/listNotionDatabasesUseCase.ts
+import type { UserNotionIntegrationRepository } from '../../domain/repositories/userNotionIntegrationRepository';
+import type { EncryptionService } from '../services/encryptionService';
+import type { NotionApiService } from '../../domain/services/notionApiService';
+import type { ListNotionDatabasesInput, ListNotionDatabasesOutput, NotionDatabaseOutputItem } from '../dtos/notionDatabaseDTOs';
+import { HTTPException } from 'hono/http-exception';
+
+export class ListNotionDatabasesUseCase {
+  constructor(
+    private readonly userNotionIntegrationRepository: UserNotionIntegrationRepository,
+    private readonly encryptionService: EncryptionService,
+    private readonly notionApiService: NotionApiService,
+  ) {}
+
+  async execute(input: ListNotionDatabasesInput): Promise<ListNotionDatabasesOutput> {
+    const { integrationId, userId } = input;
+
+    // 1. Fetch UserNotionIntegration
+    const integration = await this.userNotionIntegrationRepository.findById(integrationId, userId);
+    if (!integration) {
+      // Standard practice is to throw an error that the presentation layer can interpret.
+      // Hono's HTTPException is suitable here.
+      throw new HTTPException(404, { 
+        message: `Notion integration with ID ${integrationId} not found or not accessible by user.`,
+        cause: 'UserNotionIntegrationNotFound' 
+      });
+    }
+
+    // 2. Decrypt notionIntegrationToken
+    let decryptedToken: string;
+    try {
+      // Corrected property name based on src/domain/entities/userNotionIntegration.ts
+      decryptedToken = await this.encryptionService.decrypt(integration.notionIntegrationToken); 
+    } catch (error) {
+      console.error(`Failed to decrypt token for integration ID ${integrationId}:`, error);
+      throw new HTTPException(500, { 
+        message: 'Failed to decrypt Notion integration token.',
+        cause: 'DecryptionError'
+      });
+    }
+
+    // 3. Call notionApiService.listAccessibleDatabases()
+    try {
+      const accessibleDatabases = await this.notionApiService.listAccessibleDatabases(decryptedToken);
+      
+      // 4. Map to ListNotionDatabasesOutput
+      const output: ListNotionDatabasesOutput = accessibleDatabases.map(db => ({
+        id: db.id,
+        name: db.name,
+      }));
+      
+      return output;
+    } catch (error: any) {
+      // Log the error from Notion API service
+      console.error(`Error fetching accessible databases from Notion API for integration ID ${integrationId}:`, error);
+      // Check if it's an HTTPException from a deeper layer (like NotionApiClient if it threw one)
+      if (error instanceof HTTPException) {
+        throw error;
+      }
+      // Otherwise, wrap it in a generic 500 error
+      throw new HTTPException(500, { 
+        message: 'An error occurred while fetching accessible databases from Notion.',
+        cause: error.message || 'NotionApiError'
+      });
+    }
+  }
+}

--- a/src/domain/services/notionApiService.ts
+++ b/src/domain/services/notionApiService.ts
@@ -17,6 +17,12 @@ export interface NotionDatabaseSchema {
 	// 他にも必要な情報があれば追加 (例: parent情報とか)
 }
 
+// ADD THIS INTERFACE
+export interface AccessibleNotionDatabase {
+  id: string;
+  name: string;
+}
+
 // Notion APIとやり取りするサービスのインターフェース
 export interface NotionApiService {
 	/**

--- a/src/presentation/handlers/notionDatabaseHandler.ts
+++ b/src/presentation/handlers/notionDatabaseHandler.ts
@@ -1,0 +1,55 @@
+// src/presentation/handlers/notionDatabaseHandler.ts
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+import type { GetNotionDatabasePropertiesUseCase } from "../../application/usecases/getNotionDatabasePropertiesUseCase";
+import type { 
+    GetNotionDatabasePropertiesInput, 
+    GetNotionDatabasePropertiesOutput 
+} from "../../application/dtos/notionDatabaseDTOs";
+
+export function getNotionDatabasePropertiesHandlerFactory(
+    useCase: GetNotionDatabasePropertiesUseCase
+) {
+    return async (c: Context) => {
+        try {
+            const databaseId = c.req.param("databaseId");
+            const integrationId = c.req.query("integrationId"); // As per spec, it's a query param
+            const userId = c.var.userId; // Or c.get("userId")
+
+            if (typeof userId !== "string") {
+                console.error("CRITICAL: userId not found in context or is not a string after authMiddleware.");
+                throw new HTTPException(401, { message: "Unauthorized: User ID not found or invalid." });
+            }
+
+            if (!databaseId) {
+                throw new HTTPException(400, { message: "databaseId path parameter is required" });
+            }
+
+            if (!integrationId) {
+                // The use case treats this as mandatory.
+                throw new HTTPException(400, { message: "integrationId query parameter is required" });
+            }
+
+            const input: GetNotionDatabasePropertiesInput = {
+                databaseId,
+                userId,
+                integrationId,
+            };
+
+            const output: GetNotionDatabasePropertiesOutput = await useCase.execute(input);
+            return c.json(output, 200);
+
+        } catch (error: any) {
+            console.error(`Error in getNotionDatabasePropertiesHandler for DB ${c.req.param("databaseId")}:`, error);
+            if (error instanceof HTTPException) {
+                // Re-throw HTTPException directly if it's already one
+                throw error;
+            }
+            // For other types of errors, wrap them in a generic 500 error
+            throw new HTTPException(500, {
+                message: "Failed to get Notion database properties",
+                cause: error.message || error,
+            });
+        }
+    };
+}

--- a/src/presentation/handlers/userNotionIntegrationHandler.ts
+++ b/src/presentation/handlers/userNotionIntegrationHandler.ts
@@ -1,23 +1,78 @@
-// src/presentation/handlers/userNotionIntegrationHandler.ts (修正版)
+// src/presentation/handlers/userNotionIntegrationHandler.ts
 
-import type { Context } from "hono"; // Hono標準のContextを使う
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+// Existing Use Case Imports
 import type { CreateUserNotionIntegrationUseCase } from "../../application/usecases/createUserNotionIntegrationUseCase";
 import type { ListUserNotionIntegrationsUseCase } from "../../application/usecases/listUserNotionIntegrationsUseCase";
 import type { DeleteUserNotionIntegrationUseCase } from "../../application/usecases/deleteUserNotionIntegrationUseCase";
+
+// New Use Case Import
+import type { ListNotionDatabasesUseCase } from "../../application/usecases/listNotionDatabasesUseCase"; // Added
+
+// Existing DTO Imports
 import type {
 	CreateUserNotionIntegrationInput,
 	DeleteUserNotionIntegrationInput,
-	// Assuming CreateUserNotionIntegrationOutput is also in this DTO file or imported
 	CreateUserNotionIntegrationOutput,
 } from "../../application/dtos/userNotionIntegrationDTOs";
-import { HTTPException } from "hono/http-exception";
 
-// AuthenticatedContext インターフェースの定義は削除する！
+// New DTO Imports
+import type { 
+    ListNotionDatabasesInput, 
+    ListNotionDatabasesOutput 
+} from "../../application/dtos/notionDatabaseDTOs"; // Added
+
+
+// Factory function for the new handler
+function listUserAccessibleDatabasesHandlerFactory(
+    useCase: ListNotionDatabasesUseCase
+) {
+    return async (c: Context) => {
+        try {
+            const integrationId = c.req.param("integrationId");
+            const userId = c.var.userId; // Or c.get("userId")
+
+            if (typeof userId !== "string") {
+                console.error("CRITICAL: userId not found in context or is not a string after authMiddleware.");
+                throw new HTTPException(401, { message: "Unauthorized: User ID not found or invalid." });
+            }
+
+            if (!integrationId) {
+                throw new HTTPException(400, { message: "integrationId path parameter is required" });
+            }
+
+            const input: ListNotionDatabasesInput = {
+                integrationId,
+                userId,
+            };
+
+            const output: ListNotionDatabasesOutput = await useCase.execute(input);
+            return c.json(output, 200);
+
+        } catch (error: any) {
+            console.error("Error in listUserAccessibleDatabasesHandler:", error);
+            if (error instanceof HTTPException) {
+                // Re-throw HTTPException directly if it's already one
+                // This allows specific error codes from the use case to propagate
+                throw error;
+            }
+            // For other types of errors, wrap them in a generic 500 error
+            throw new HTTPException(500, {
+                message: "Failed to list accessible Notion databases",
+                cause: error.message || error,
+            });
+        }
+    };
+}
+
 
 export function createUserNotionIntegrationHandlers(
 	createUseCase: CreateUserNotionIntegrationUseCase,
 	listUseCase: ListUserNotionIntegrationsUseCase,
 	deleteUseCase: DeleteUserNotionIntegrationUseCase,
+    listDatabasesUseCase: ListNotionDatabasesUseCase // Added new parameter
 ) {
 	const createIntegrationHandler = async (c: Context) => {
 		try {
@@ -25,121 +80,79 @@ export function createUserNotionIntegrationHandlers(
 				integrationName: string;
 				notionIntegrationToken: string;
 			}>();
-
-			// authMiddlewareを通過していれば、userId は string 型として取得できるはず
-			// Honoの型拡張により、c.var.userId も string としてアクセス可能
-			// c.get() の方がより明示的かもしれない
-			const userId = c.var.userId; // または c.get("userId")
-
-			// 型ガード (より安全にするなら)
+			const userId = c.var.userId; 
 			if (typeof userId !== "string") {
-				console.error(
-					"CRITICAL: userId not found in context or is not a string after authMiddleware.",
-				);
-				throw new HTTPException(401, {
-					message: "Unauthorized: User ID not found or invalid.",
-				});
+				console.error("CRITICAL: userId not found in context or is not a string after authMiddleware.");
+				throw new HTTPException(401, { message: "Unauthorized: User ID not found or invalid." });
 			}
-
 			if (!integrationName || !notionIntegrationToken) {
-				throw new HTTPException(400, {
-					message: "integrationName and notionIntegrationToken are required",
-				});
+				throw new HTTPException(400, { message: "integrationName and notionIntegrationToken are required" });
 			}
-
 			const input: CreateUserNotionIntegrationInput = {
-				userId, // ここでは userId は string と確定
+				userId,
 				integrationName,
 				notionIntegrationToken,
 			};
-
 			const output = await createUseCase.execute(input);
 			return c.json(output, 201);
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 		} catch (error: any) {
 			console.error("Error in createIntegrationHandler:", error);
 			if (error instanceof HTTPException) throw error;
-			throw new HTTPException(500, {
-				message: "Failed to create Notion integration",
-				cause: error,
-			});
+			throw new HTTPException(500, { message: "Failed to create Notion integration", cause: error });
 		}
 	};
 
 	const listIntegrationsHandler = async (c: Context) => {
-		// c の型を Context に変更
 		try {
-			const userId = c.var.userId; // または c.get("userId")
+			const userId = c.var.userId;
 			if (typeof userId !== "string") {
-				console.error(
-					"CRITICAL: userId not found in context or is not a string after authMiddleware.",
-				);
-				throw new HTTPException(401, {
-					message: "Unauthorized: User ID not found or invalid.",
-				});
+				console.error("CRITICAL: userId not found in context or is not a string after authMiddleware.");
+				throw new HTTPException(401, { message: "Unauthorized: User ID not found or invalid." });
 			}
 			const output = await listUseCase.execute({ userId });
 			return c.json(output, 200);
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 		} catch (error: any) {
 			console.error("Error in listIntegrationsHandler:", error);
-			throw new HTTPException(500, {
-				message: "Failed to list Notion integrations",
-				cause: error,
-			});
+			if (error instanceof HTTPException) throw error; // Propagate HTTPException
+			throw new HTTPException(500, { message: "Failed to list Notion integrations", cause: error });
 		}
 	};
 
 	const deleteIntegrationHandler = async (c: Context) => {
-		// c の型を Context に変更
 		try {
 			const integrationId = c.req.param("integrationId");
-			const userId = c.var.userId; // または c.get("userId")
-
+			const userId = c.var.userId; 
 			if (typeof userId !== "string") {
-				console.error(
-					"CRITICAL: userId not found in context or is not a string after authMiddleware.",
-				);
-				throw new HTTPException(401, {
-					message: "Unauthorized: User ID not found or invalid.",
-				});
+				console.error("CRITICAL: userId not found in context or is not a string after authMiddleware.");
+				throw new HTTPException(401, { message: "Unauthorized: User ID not found or invalid." });
 			}
-
 			if (!integrationId) {
-				throw new HTTPException(400, {
-					message: "integrationId path parameter is required",
-				});
+				throw new HTTPException(400, { message: "integrationId path parameter is required" });
 			}
-
 			const input: DeleteUserNotionIntegrationInput = {
 				integrationId,
 				userId,
 			};
-
 			const result = await deleteUseCase.execute(input);
-
 			if (!result.success) {
-				throw new HTTPException(404, {
-					message:
-						result.message ||
-						`Notion integration with ID ${integrationId} not found.`,
-				});
+                // Use a more specific error from the use case if available, otherwise default
+				throw new HTTPException(result.statusCode || 404, { message: result.message || `Notion integration with ID ${integrationId} not found or action failed.` });
 			}
-			return c.json({ message: result.message }, 200); // 成功時は200 OKとメッセージを返す例
-			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+			return c.json({ message: result.message }, 200);
 		} catch (error: any) {
 			console.error("Error in deleteIntegrationHandler:", error);
-			if (error instanceof HTTPException) throw error;
-			throw new HTTPException(500, {
-				message: "Failed to delete Notion integration",
-				cause: error,
-			});
+			if (error instanceof HTTPException) throw error; // Propagate HTTPException
+			throw new HTTPException(500, { message: "Failed to delete Notion integration", cause: error });
 		}
 	};
+
+    // Instantiate the new handler
+    const listUserAccessibleDatabasesHandler = listUserAccessibleDatabasesHandlerFactory(listDatabasesUseCase);
 
 	return {
 		createIntegrationHandler,
 		listIntegrationsHandler,
 		deleteIntegrationHandler,
+        listUserAccessibleDatabasesHandler, // Added new handler
 	};
 }


### PR DESCRIPTION
I've implemented two new API endpoints for the Notifier App:

1.  `GET /api/v1/me/notion-integrations/{integrationId}/databases`: This retrieves a list of Notion databases accessible by your specified Notion integration. This allows you to select a target database when creating notification templates.

2.  `GET /api/v1/notion-databases/{databaseId}/properties`: This fetches property information (columns) for a specific Notion database, using a specified user Notion integration for access. This enables dynamic UI generation for notification conditions.

Changes include:
- Definition of DTOs for API inputs and outputs.
- Extension of `NotionApiService` and `NotionApiClient` to support listing accessible databases (with pagination) and leveraging existing schema retrieval for properties.
- Creation of `ListNotionDatabasesUseCase` and `GetNotionDatabasePropertiesUseCase` to handle business logic, including token decryption, data transformation (Record to Array for properties), and caching for database properties.
- Addition of corresponding API handlers in `userNotionIntegrationHandler.ts` and a new `notionDatabaseHandler.ts`.
- Routing configuration in `main.ts` for the new endpoints.
- Updated `docs/api_reference.md` with detailed specifications for both new APIs.

All endpoints are authenticated using Firebase ID tokens and follow the existing clean architecture principles of the application. Error handling and appropriate HTTP status codes are implemented.